### PR TITLE
Fix for GCC 15.1 compatibility

### DIFF
--- a/polygon.mod/earcut/include/mapbox/earcut.hpp
+++ b/polygon.mod/earcut/include/mapbox/earcut.hpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <utility>


### PR DESCRIPTION
https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes

Seems cstdint needs to be explicitly included for it to compile using GCC 15.1

Not sure if this can cause problems when not using GCC 15.1 or below though, so please be advised.

EDIT: Saw now that the earcut repo also has this fix so should be fine! (https://github.com/mapbox/earcut.hpp/commits/master/)